### PR TITLE
Update README.md to include installation of clinfun

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Simply run the following from an R console:
 if (!require("devtools"))
   install.packages("devtools")
 devtools::install_github("dungtsa/BayesianPickWinner",force = TRUE)
+install.packages("clinfun")
 ```
 
 ## Getting Started


### PR DESCRIPTION
The app requires the `clinfun` package to work properly (without it, it throws an error because the `ph2simon` function is missing). I propose adding the installation of `clinfun` to the installation instructions in the Readme.